### PR TITLE
Handle diff exit code

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7197,33 +7197,35 @@ const checkAndReleaseLibrary = (payload) => __awaiter(void 0, void 0, void 0, fu
         return;
     }
     console.log('Diff detected. Opening pull request');
-    output = '';
-    yield exec_1.exec('cat package.json', [], options);
-    const newVersion = JSON.parse(output).version;
-    if (!newVersion) {
-        console.log('Could not find version number');
-        return;
-    }
-    const message = `${config.prTitlePrefix}${newVersion}`;
-    const newBranch = `${config.newBranchPrefix}${newVersion}`;
-    yield exec_1.exec(`git config --global user.email "${config.commitEmail}"`);
-    yield exec_1.exec(`git config --global user.name "${config.commitUser}"`);
-    yield exec_1.exec(`git remote set-url origin "https://git:${token}@github.com/${payload.repository.full_name}.git"`);
-    yield exec_1.exec(`git checkout -b "${newBranch}"`);
-    yield exec_1.exec(`git add package.json`);
-    yield exec_1.exec(`git add package-lock.json`);
-    yield exec_1.exec(`git commit -m "${message}"`);
-    yield exec_1.exec(`git status`);
-    yield exec_1.exec(`git push -u origin "${newBranch}"`);
-    const octokit = github.getOctokit(token);
-    yield octokit.pulls.create({
-        owner: payload.repository.owner.login,
-        repo: payload.repository.name,
-        title: message,
-        body: `Updating the version number in the repository following the release of v${newVersion}`,
-        base: config.releaseBranch,
-        head: newBranch,
-    });
+    // output = '';
+    // await exec('cat package.json', [], options);
+    // const newVersion = ((JSON.parse(output) as unknown) as Package).version;
+    // if (!newVersion) {
+    // 	console.log('Could not find version number');
+    // 	return;
+    // }
+    // const message = `${config.prTitlePrefix}${newVersion}`;
+    // const newBranch = `${config.newBranchPrefix}${newVersion}`;
+    // await exec(`git config --global user.email "${config.commitEmail}"`);
+    // await exec(`git config --global user.name "${config.commitUser}"`);
+    // await exec(
+    // 	`git remote set-url origin "https://git:${token}@github.com/${payload.repository.full_name}.git"`,
+    // );
+    // await exec(`git checkout -b "${newBranch}"`);
+    // await exec(`git add package.json`);
+    // await exec(`git add package-lock.json`);
+    // await exec(`git commit -m "${message}"`);
+    // await exec(`git status`);
+    // await exec(`git push -u origin "${newBranch}"`);
+    // const octokit = github.getOctokit(token);
+    // await octokit.pulls.create({
+    // 	owner: payload.repository.owner.login,
+    // 	repo: payload.repository.name,
+    // 	title: message,
+    // 	body: `Updating the version number in the repository following the release of v${newVersion}`,
+    // 	base: config.releaseBranch,
+    // 	head: newBranch,
+    // });
 });
 function run() {
     return __awaiter(this, void 0, void 0, function* () {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7171,10 +7171,10 @@ const validateAndMergePR = (pullRequestQueryData) => __awaiter(void 0, void 0, v
 const checkAndReleaseLibrary = (payload) => __awaiter(void 0, void 0, void 0, function* () {
     console.log('checkAndReleaseLibrary');
     const token = core.getInput('github-token');
-    if (payload.ref !== `refs/heads/${config.releaseBranch}`) {
-        console.log(`Push is not to ${config.releaseBranch}, ignoring`);
-        return;
-    }
+    // if (payload.ref !== `refs/heads/${config.releaseBranch}`) {
+    // 	console.log(`Push is not to ${config.releaseBranch}, ignoring`);
+    // 	return;
+    // }
     let output = '';
     let error = '';
     const options = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7176,14 +7176,22 @@ const checkAndReleaseLibrary = (payload) => __awaiter(void 0, void 0, void 0, fu
         return;
     }
     let output = '';
+    let error = '';
     const options = {
         listeners: {
             stdout: (data) => {
                 output += data.toString();
             },
+            stderr: (data) => {
+                error += data.toString();
+            },
         },
     };
-    yield exec_1.exec('git diff --quiet', [], options);
+    // Write a new file to make a diff so that we can see what git diff does
+    yield exec_1.exec('touch test.md');
+    yield exec_1.exec('git diff --quiet', [], Object.assign(Object.assign({}, options), { ignoreReturnCode: true }));
+    console.log(output);
+    console.log(error);
     if (!output) {
         console.log('New release not created. No further action needed.');
         return;

--- a/dist/index.js
+++ b/dist/index.js
@@ -7171,62 +7171,51 @@ const validateAndMergePR = (pullRequestQueryData) => __awaiter(void 0, void 0, v
 const checkAndReleaseLibrary = (payload) => __awaiter(void 0, void 0, void 0, function* () {
     console.log('checkAndReleaseLibrary');
     const token = core.getInput('github-token');
-    // if (payload.ref !== `refs/heads/${config.releaseBranch}`) {
-    // 	console.log(`Push is not to ${config.releaseBranch}, ignoring`);
-    // 	return;
-    // }
-    let output = '';
-    let error = '';
-    const options = {
-        listeners: {
-            stdout: (data) => {
-                output += data.toString();
-            },
-            stderr: (data) => {
-                error += data.toString();
-            },
-        },
-    };
-    // Write a new file to make a diff so that we can see what git diff does
-    yield exec_1.exec('touch test.md');
-    const ret = yield exec_1.exec('git diff --quiet', [], Object.assign(Object.assign({}, options), { ignoreReturnCode: true }));
-    console.log(ret);
-    console.log(output);
-    console.log(error);
-    if (!output) {
+    if (payload.ref !== `refs/heads/${config.releaseBranch}`) {
+        console.log(`Push is not to ${config.releaseBranch}, ignoring`);
+        return;
+    }
+    const ret = yield exec_1.exec('git diff --quiet', [], {
+        ignoreReturnCode: true,
+    });
+    if (!ret) {
         console.log('New release not created. No further action needed.');
         return;
     }
     console.log('Diff detected. Opening pull request');
-    // output = '';
-    // await exec('cat package.json', [], options);
-    // const newVersion = ((JSON.parse(output) as unknown) as Package).version;
-    // if (!newVersion) {
-    // 	console.log('Could not find version number');
-    // 	return;
-    // }
-    // const message = `${config.prTitlePrefix}${newVersion}`;
-    // const newBranch = `${config.newBranchPrefix}${newVersion}`;
-    // await exec(`git config --global user.email "${config.commitEmail}"`);
-    // await exec(`git config --global user.name "${config.commitUser}"`);
-    // await exec(
-    // 	`git remote set-url origin "https://git:${token}@github.com/${payload.repository.full_name}.git"`,
-    // );
-    // await exec(`git checkout -b "${newBranch}"`);
-    // await exec(`git add package.json`);
-    // await exec(`git add package-lock.json`);
-    // await exec(`git commit -m "${message}"`);
-    // await exec(`git status`);
-    // await exec(`git push -u origin "${newBranch}"`);
-    // const octokit = github.getOctokit(token);
-    // await octokit.pulls.create({
-    // 	owner: payload.repository.owner.login,
-    // 	repo: payload.repository.name,
-    // 	title: message,
-    // 	body: `Updating the version number in the repository following the release of v${newVersion}`,
-    // 	base: config.releaseBranch,
-    // 	head: newBranch,
-    // });
+    let output = '';
+    yield exec_1.exec('cat package.json', [], {
+        listeners: {
+            stdout: (data) => {
+                output += data.toString();
+            },
+        },
+    });
+    const newVersion = JSON.parse(output).version;
+    if (!newVersion) {
+        console.log('Could not find version number');
+        return;
+    }
+    const message = `${config.prTitlePrefix}${newVersion}`;
+    const newBranch = `${config.newBranchPrefix}${newVersion}`;
+    yield exec_1.exec(`git config --global user.email "${config.commitEmail}"`);
+    yield exec_1.exec(`git config --global user.name "${config.commitUser}"`);
+    yield exec_1.exec(`git remote set-url origin "https://git:${token}@github.com/${payload.repository.full_name}.git"`);
+    yield exec_1.exec(`git checkout -b "${newBranch}"`);
+    yield exec_1.exec(`git add package.json`);
+    yield exec_1.exec(`git add package-lock.json`);
+    yield exec_1.exec(`git commit -m "${message}"`);
+    yield exec_1.exec(`git status`);
+    yield exec_1.exec(`git push -u origin "${newBranch}"`);
+    const octokit = github.getOctokit(token);
+    yield octokit.pulls.create({
+        owner: payload.repository.owner.login,
+        repo: payload.repository.name,
+        title: message,
+        body: `Updating the version number in the repository following the release of v${newVersion}`,
+        base: config.releaseBranch,
+        head: newBranch,
+    });
 });
 function run() {
     return __awaiter(this, void 0, void 0, function* () {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7189,7 +7189,8 @@ const checkAndReleaseLibrary = (payload) => __awaiter(void 0, void 0, void 0, fu
     };
     // Write a new file to make a diff so that we can see what git diff does
     yield exec_1.exec('touch test.md');
-    yield exec_1.exec('git diff --quiet', [], Object.assign(Object.assign({}, options), { ignoreReturnCode: true }));
+    const ret = yield exec_1.exec('git diff --quiet', [], Object.assign(Object.assign({}, options), { ignoreReturnCode: true }));
+    console.log(ret);
     console.log(output);
     console.log(error);
     if (!output) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,10 +258,10 @@ const checkAndReleaseLibrary = async (payload: PushEvent) => {
 	console.log('checkAndReleaseLibrary');
 	const token = core.getInput('github-token');
 
-	if (payload.ref !== `refs/heads/${config.releaseBranch}`) {
-		console.log(`Push is not to ${config.releaseBranch}, ignoring`);
-		return;
-	}
+	// if (payload.ref !== `refs/heads/${config.releaseBranch}`) {
+	// 	console.log(`Push is not to ${config.releaseBranch}, ignoring`);
+	// 	return;
+	// }
 
 	let output = '';
 	let error = '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,8 +279,12 @@ const checkAndReleaseLibrary = async (payload: PushEvent) => {
 	// Write a new file to make a diff so that we can see what git diff does
 	await exec('touch test.md');
 
-	await exec('git diff --quiet', [], { ...options, ignoreReturnCode: true });
+	const ret = await exec('git diff --quiet', [], {
+		...options,
+		ignoreReturnCode: true,
+	});
 
+	console.log(ret);
 	console.log(output);
 	console.log(error);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,15 +264,25 @@ const checkAndReleaseLibrary = async (payload: PushEvent) => {
 	}
 
 	let output = '';
+	let error = '';
 	const options = {
 		listeners: {
 			stdout: (data: Buffer) => {
 				output += data.toString();
 			},
+			stderr: (data: Buffer) => {
+				error += data.toString();
+			},
 		},
 	};
 
-	await exec('git diff --quiet', [], options);
+	// Write a new file to make a diff so that we can see what git diff does
+	await exec('touch test.md');
+
+	await exec('git diff --quiet', [], { ...options, ignoreReturnCode: true });
+
+	console.log(output);
+	console.log(error);
 
 	if (!output) {
 		console.log('New release not created. No further action needed.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,42 +291,42 @@ const checkAndReleaseLibrary = async (payload: PushEvent) => {
 
 	console.log('Diff detected. Opening pull request');
 
-	output = '';
-	await exec('cat package.json', [], options);
+	// output = '';
+	// await exec('cat package.json', [], options);
 
-	const newVersion = ((JSON.parse(output) as unknown) as Package).version;
+	// const newVersion = ((JSON.parse(output) as unknown) as Package).version;
 
-	if (!newVersion) {
-		console.log('Could not find version number');
-		return;
-	}
+	// if (!newVersion) {
+	// 	console.log('Could not find version number');
+	// 	return;
+	// }
 
-	const message = `${config.prTitlePrefix}${newVersion}`;
-	const newBranch = `${config.newBranchPrefix}${newVersion}`;
+	// const message = `${config.prTitlePrefix}${newVersion}`;
+	// const newBranch = `${config.newBranchPrefix}${newVersion}`;
 
-	await exec(`git config --global user.email "${config.commitEmail}"`);
-	await exec(`git config --global user.name "${config.commitUser}"`);
-	await exec(
-		`git remote set-url origin "https://git:${token}@github.com/${payload.repository.full_name}.git"`,
-	);
+	// await exec(`git config --global user.email "${config.commitEmail}"`);
+	// await exec(`git config --global user.name "${config.commitUser}"`);
+	// await exec(
+	// 	`git remote set-url origin "https://git:${token}@github.com/${payload.repository.full_name}.git"`,
+	// );
 
-	await exec(`git checkout -b "${newBranch}"`);
-	await exec(`git add package.json`);
-	await exec(`git add package-lock.json`);
-	await exec(`git commit -m "${message}"`);
-	await exec(`git status`);
-	await exec(`git push -u origin "${newBranch}"`);
+	// await exec(`git checkout -b "${newBranch}"`);
+	// await exec(`git add package.json`);
+	// await exec(`git add package-lock.json`);
+	// await exec(`git commit -m "${message}"`);
+	// await exec(`git status`);
+	// await exec(`git push -u origin "${newBranch}"`);
 
-	const octokit = github.getOctokit(token);
+	// const octokit = github.getOctokit(token);
 
-	await octokit.pulls.create({
-		owner: payload.repository.owner.login,
-		repo: payload.repository.name,
-		title: message,
-		body: `Updating the version number in the repository following the release of v${newVersion}`,
-		base: config.releaseBranch,
-		head: newBranch,
-	});
+	// await octokit.pulls.create({
+	// 	owner: payload.repository.owner.login,
+	// 	repo: payload.repository.name,
+	// 	title: message,
+	// 	body: `Updating the version number in the repository following the release of v${newVersion}`,
+	// 	base: config.releaseBranch,
+	// 	head: newBranch,
+	// });
 };
 
 async function run(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,79 +258,64 @@ const checkAndReleaseLibrary = async (payload: PushEvent) => {
 	console.log('checkAndReleaseLibrary');
 	const token = core.getInput('github-token');
 
-	// if (payload.ref !== `refs/heads/${config.releaseBranch}`) {
-	// 	console.log(`Push is not to ${config.releaseBranch}, ignoring`);
-	// 	return;
-	// }
-
-	let output = '';
-	let error = '';
-	const options = {
-		listeners: {
-			stdout: (data: Buffer) => {
-				output += data.toString();
-			},
-			stderr: (data: Buffer) => {
-				error += data.toString();
-			},
-		},
-	};
-
-	// Write a new file to make a diff so that we can see what git diff does
-	await exec('touch test.md');
+	if (payload.ref !== `refs/heads/${config.releaseBranch}`) {
+		console.log(`Push is not to ${config.releaseBranch}, ignoring`);
+		return;
+	}
 
 	const ret = await exec('git diff --quiet', [], {
-		...options,
 		ignoreReturnCode: true,
 	});
 
-	console.log(ret);
-	console.log(output);
-	console.log(error);
-
-	if (!output) {
+	if (!ret) {
 		console.log('New release not created. No further action needed.');
 		return;
 	}
 
 	console.log('Diff detected. Opening pull request');
 
-	// output = '';
-	// await exec('cat package.json', [], options);
+	let output = '';
+	await exec('cat package.json', [], {
+		listeners: {
+			stdout: (data: Buffer) => {
+				output += data.toString();
+			},
+		},
+	});
 
-	// const newVersion = ((JSON.parse(output) as unknown) as Package).version;
+	const newVersion = ((JSON.parse(output) as unknown) as Package).version;
 
-	// if (!newVersion) {
-	// 	console.log('Could not find version number');
-	// 	return;
-	// }
+	if (!newVersion) {
+		console.log('Could not find version number');
+		return;
+	}
 
-	// const message = `${config.prTitlePrefix}${newVersion}`;
-	// const newBranch = `${config.newBranchPrefix}${newVersion}`;
+	const message = `${config.prTitlePrefix}${newVersion}`;
+	const newBranch = `${config.newBranchPrefix}${newVersion}`;
 
-	// await exec(`git config --global user.email "${config.commitEmail}"`);
-	// await exec(`git config --global user.name "${config.commitUser}"`);
-	// await exec(
-	// 	`git remote set-url origin "https://git:${token}@github.com/${payload.repository.full_name}.git"`,
-	// );
+	await exec(`git config --global user.email "${config.commitEmail}"`);
+	await exec(`git config --global user.name "${config.commitUser}"`);
+	await exec(
+		`git remote set-url origin "https://git:${token}@github.com/${payload.repository.full_name}.git"`,
+	);
 
-	// await exec(`git checkout -b "${newBranch}"`);
-	// await exec(`git add package.json`);
-	// await exec(`git add package-lock.json`);
-	// await exec(`git commit -m "${message}"`);
-	// await exec(`git status`);
-	// await exec(`git push -u origin "${newBranch}"`);
+	await exec(`git checkout -b "${newBranch}"`);
+	await exec(`git add package.json`);
+	await exec(`git add package-lock.json`);
+	await exec(`git commit -m "${message}"`);
+	await exec(`git status`);
+	await exec(`git push -u origin "${newBranch}"`);
 
-	// const octokit = github.getOctokit(token);
+	const octokit = github.getOctokit(token);
 
-	// await octokit.pulls.create({
-	// 	owner: payload.repository.owner.login,
-	// 	repo: payload.repository.name,
-	// 	title: message,
-	// 	body: `Updating the version number in the repository following the release of v${newVersion}`,
-	// 	base: config.releaseBranch,
-	// 	head: newBranch,
-	// });
+	await octokit.pulls.create({
+		owner: payload.repository.owner.login,
+		repo: payload.repository.name,
+		title: message,
+		body: `Updating the version number in the repository following the release of v${newVersion}`,
+		base: config.releaseBranch,
+		head: newBranch,
+	});
 };
 
 async function run(): Promise<void> {


### PR DESCRIPTION
## What does this change?

This PR updates the logic on push events to use the return code of `git diff --quiet` to determine whether there are any changes. It also adds the `ignoreReturnCode` option when calling the command so that the process doesn't quit if there are changes.

## How to test

Merge something into main on a repo which uses this action and see it run.

## How can we measure success?

The process doesn't exit if a diff is detected.