### PR TITLE
Add CI check that build is up to date

### DIFF
--- a/script/build
+++ b/script/build
@@ -9,3 +9,10 @@ if [ $CI ] ; then
 fi
 
 npm run build
+
+if [ $CI ] ; then
+	if ! git diff --quiet; then
+		echo "Changes detected after running build. It looks like you may have forgetten to run and check in the new build."
+		exit 1
+	fi
+fi


### PR DESCRIPTION
## What does this change?

This PR adds a check in the `./script/build` file that runs in the CI environment which checks if there are any diffs after the build has fun. This means that the status checks will fail if the new build has not been commited. 

## How to test

Try updating the action but not running the build and see the CI checks fail

## How can we measure success?

It isn't possible to merge code that doesn't have an up-to-date build.